### PR TITLE
cosmetic changes to /check-requirements

### DIFF
--- a/cogs/StaffRequirements.py
+++ b/cogs/StaffRequirements.py
@@ -4,6 +4,8 @@ from os import getenv
 import discord.ui
 from discord.ext import commands
 
+from humanize import precisedelta
+
 from util.EmbedBuilder import EmbedBuilder
 from util.Logging import log
 
@@ -34,20 +36,20 @@ class StaffRequirement(commands.Cog):
         """
         account = ctx.author
 
-        time_since_creation = (
-            datetime.now(tz=account.created_at.tzinfo) - account.created_at
-        )
+        time_since_creation = datetime.now(tz=account.created_at.tzinfo) - account.created_at
         time_since_join = datetime.now(tz=account.joined_at.tzinfo) - account.joined_at
 
         fields = [
             [
                 "Created",
-                f"{account.created_at.strftime('%B %d, %Y')}\n{strfdelta(time_since_creation.days/365.25,'year') if time_since_creation.days/365.25 >= 1 else ''} {strfdelta(time_since_creation.days % 365.25, 'day')} ago",
+                f"""{account.created_at.strftime('%B %d, %Y')}
+                {precisedelta(time_since_creation, minimum_unit='days', format="%.0F")} ago""",
                 True,
             ],
             [
                 "Joined",
-                f"{account.joined_at.strftime('%B %d, %Y')}\n{strfdelta(time_since_join.days/365.25, 'year') if time_since_join.days/365.25 >= 1 else ''} {strfdelta(time_since_join.days % 365.25, 'day')} ago",
+                f"""{account.joined_at.strftime('%B %d, %Y')}
+                {precisedelta(time_since_join, minimum_unit='days', format="%.0F")} ago""",
                 True,
             ],
         ]
@@ -55,9 +57,7 @@ class StaffRequirement(commands.Cog):
         # if staff requirements are met
         # time since creation is at least 1 year (52 weeks) AND
         # time since join is at least 30 days
-        if time_since_creation >= timedelta(weeks=52) and time_since_join >= timedelta(
-            days=30
-        ):
+        if time_since_creation >= timedelta(weeks=52) and time_since_join >= timedelta(days=30):
             embed = EmbedBuilder(
                 title="Congratulations!",
                 description="You meet the basic requirements for staff. You may apply for staff below.",
@@ -66,55 +66,23 @@ class StaffRequirement(commands.Cog):
             ).build()
             await ctx.respond(embed=embed, ephemeral=True, view=StaffAppView())
         else:
+            wait_time = max(
+                timedelta(weeks=52) - time_since_creation,
+                timedelta(days=30) - time_since_join
+            )
+
             embed = EmbedBuilder(
                 title="Missing Requirements",
-                description=f"Unfortunately, you do not meet the basic requirements in order to apply for staff.\n\nYour account must be at least 1 year old and you must have been a member of the server for at least 30 days.\n\nYou will be eligible to apply for staff in **{check_missing_requirements(time_since_creation, time_since_join)}**.",
+                description=f"""Unfortunately, you do not meet the basic requirements in order to apply for staff.
+                Your account must be at least 1 year old and you must have been a member of the server for at least 30 days.
+
+                You will be eligible to apply for staff in **{precisedelta(wait_time, minimum_unit='days', format="%.0F")}**.""",
                 fields=fields,
                 color=0xFF0000,  # RED
             ).build()
             await ctx.respond(embed=embed, ephemeral=True)
 
         log(f"User {account} checked their requirements in {ctx.guild}.")
-
-
-def strfdelta(num: float, word: str) -> str:
-    """
-    It takes a number and a word, and returns a string that says the number and the word, with an "s" if
-    the number is not 1
-
-    :param num: The number of seconds to convert
-    :type num: float
-    :param word: The word to use for the time unit
-    :type word: str
-    :return: A string with the number of days, hours, minutes, and seconds.
-    """
-    return f"{num:.0f} {word}{'s' if num != 1 else ''}"
-
-
-def check_missing_requirements(
-    time_since_creation: timedelta, time_since_join: timedelta
-) -> str:
-    """
-    It takes two `timedelta` objects, and returns a string of the missing requirements for the user to
-    be eligible for the role
-
-    :param time_since_creation: timedelta
-    :type time_since_creation: timedelta
-    :param time_since_join: timedelta = datetime.now() - member.joined_at
-    :type time_since_join: timedelta
-    :return: A string of the missing requirements.
-    """
-    missing_requirements = []
-    if time_since_creation < timedelta(weeks=52):
-        missing_requirements.append(
-            f"{strfdelta((timedelta(weeks=52) - time_since_creation).days/365.25, 'year') if (timedelta(weeks=52) - time_since_creation).days/365.25 >= 1 else ''} {strfdelta((timedelta(weeks=52) - time_since_creation).days % 365.25, 'day')}"
-        )
-    if time_since_join < timedelta(days=30):
-        missing_requirements.append(
-            f"{strfdelta((timedelta(days=30) - time_since_join).days/365.25, 'year') if (timedelta(days=30) - time_since_join).days/365.25 >= 1 else ''} {strfdelta((timedelta(days=30) - time_since_join).days % 365.25, 'day')}"
-        )
-    return ", ".join(missing_requirements)
-
 
 def setup(bot: commands.Bot) -> None:
     bot.add_cog(StaffRequirement(bot))

--- a/cogs/StaffRequirements.py
+++ b/cogs/StaffRequirements.py
@@ -3,7 +3,6 @@ from os import getenv
 
 import discord.ui
 from discord.ext import commands
-
 from humanize import precisedelta
 
 from util.EmbedBuilder import EmbedBuilder
@@ -36,7 +35,9 @@ class StaffRequirement(commands.Cog):
         """
         account = ctx.author
 
-        time_since_creation = datetime.now(tz=account.created_at.tzinfo) - account.created_at
+        time_since_creation = (
+            datetime.now(tz=account.created_at.tzinfo) - account.created_at
+        )
         time_since_join = datetime.now(tz=account.joined_at.tzinfo) - account.joined_at
 
         fields = [
@@ -57,7 +58,9 @@ class StaffRequirement(commands.Cog):
         # if staff requirements are met
         # time since creation is at least 1 year (52 weeks) AND
         # time since join is at least 30 days
-        if time_since_creation >= timedelta(weeks=52) and time_since_join >= timedelta(days=30):
+        if time_since_creation >= timedelta(weeks=52) and time_since_join >= timedelta(
+            days=30
+        ):
             embed = EmbedBuilder(
                 title="Congratulations!",
                 description="You meet the basic requirements for staff. You may apply for staff below.",
@@ -68,7 +71,7 @@ class StaffRequirement(commands.Cog):
         else:
             wait_time = max(
                 timedelta(weeks=52) - time_since_creation,
-                timedelta(days=30) - time_since_join
+                timedelta(days=30) - time_since_join,
             )
 
             embed = EmbedBuilder(
@@ -83,6 +86,7 @@ class StaffRequirement(commands.Cog):
             await ctx.respond(embed=embed, ephemeral=True)
 
         log(f"User {account} checked their requirements in {ctx.guild}.")
+
 
 def setup(bot: commands.Bot) -> None:
     bot.add_cog(StaffRequirement(bot))

--- a/cogs/StaffRequirements.py
+++ b/cogs/StaffRequirements.py
@@ -88,8 +88,7 @@ def strfdelta(num: float, word: str) -> str:
     :type word: str
     :return: A string with the number of days, hours, minutes, and seconds.
     """
-    rounded_num = round(num)
-    return f"{rounded_num} {word}{'s' if rounded_num != 1 else ''}"
+    return f"{num:.0f} {word}{'s' if num != 1 else ''}"
 
 
 def check_missing_requirements(

--- a/cogs/StaffRequirements.py
+++ b/cogs/StaffRequirements.py
@@ -1,16 +1,20 @@
 from datetime import datetime, timedelta
+from os import getenv
 
 import discord.ui
 from discord.ext import commands
 
 from util.EmbedBuilder import EmbedBuilder
 from util.Logging import log
-from os import getenv
+
 
 class StaffAppView(discord.ui.View):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(timeout=None)
-        self.add_item(discord.ui.Button(label="Apply Now", url=getenv('staff_google_form')))
+        self.add_item(
+            discord.ui.Button(label="Apply Now", url=getenv("staff_google_form"))
+        )
+
 
 class StaffRequirement(commands.Cog):
     def __init__(self, bot: commands.Bot) -> None:
@@ -24,53 +28,94 @@ class StaffRequirement(commands.Cog):
     async def checkreqs(self, ctx: commands.Context) -> None:
         """
         It checks if the user meets the requirements to apply for staff
-        
+
         :param ctx: commands.Context
         :type ctx: commands.Context
         """
         account = ctx.author
 
-        time_since_creation = datetime.now(tz=account.created_at.tzinfo) - account.created_at
+        time_since_creation = (
+            datetime.now(tz=account.created_at.tzinfo) - account.created_at
+        )
         time_since_join = datetime.now(tz=account.joined_at.tzinfo) - account.joined_at
 
-        fields=[
+        fields = [
             [
                 "Created",
-                f"{account.created_at.strftime('%B %d, %Y')}\n{strfdelta(time_since_creation.days/365.25,'year')}, {strfdelta(time_since_creation.days % 365.25, 'day')} ago",
-                True
+                f"{account.created_at.strftime('%B %d, %Y')}\n{strfdelta(time_since_creation.days/365.25,'year') if time_since_creation.days/365.25 >= 1 else ''} {strfdelta(time_since_creation.days % 365.25, 'day')} ago",
+                True,
             ],
             [
                 "Joined",
-                f"{account.joined_at.strftime('%B %d, %Y')}\n{strfdelta(time_since_join.days/365.25, 'year')}, {strfdelta(time_since_join.days % 365.25, 'day')} ago",
-                True
-            ]
+                f"{account.joined_at.strftime('%B %d, %Y')}\n{strfdelta(time_since_join.days/365.25, 'year') if time_since_join.days/365.25 >= 1 else ''} {strfdelta(time_since_join.days % 365.25, 'day')} ago",
+                True,
+            ],
         ]
 
         # if staff requirements are met
         # time since creation is at least 1 year (52 weeks) AND
         # time since join is at least 30 days
-        if time_since_creation >= timedelta(weeks=52) and time_since_join >= timedelta(days=30):
+        if time_since_creation >= timedelta(weeks=52) and time_since_join >= timedelta(
+            days=30
+        ):
             embed = EmbedBuilder(
                 title="Congratulations!",
                 description="You meet the basic requirements for staff. You may apply for staff below.",
                 fields=fields,
-                color=0x39ff14 # GREEN
+                color=0x39FF14,  # GREEN
             ).build()
             await ctx.respond(embed=embed, ephemeral=True, view=StaffAppView())
         else:
             embed = EmbedBuilder(
                 title="Missing Requirements",
-                description=f"Unfortunately, you do not meet the basic requirements in order to apply for staff. Your account must be at least 1 year old and you must have been a member of the server for at least 30 days.",
+                description=f"Unfortunately, you do not meet the basic requirements in order to apply for staff.\n\nYour account must be at least 1 year old and you must have been a member of the server for at least 30 days.\n\nYou will be eligible to apply for staff in **{check_missing_requirements(time_since_creation, time_since_join)}**.",
                 fields=fields,
-                color=0xff0000 # RED
+                color=0xFF0000,  # RED
             ).build()
             await ctx.respond(embed=embed, ephemeral=True)
 
         log(f"User {account} checked their requirements in {ctx.guild}.")
 
-def strfdelta(num: float, word: str) -> str:
-    rounded_num = round(num)
-    return f"{rounded_num} {word if rounded_num == 1 else word + 's'}"
 
-def setup(bot) -> None:
+def strfdelta(num: float, word: str) -> str:
+    """
+    It takes a number and a word, and returns a string that says the number and the word, with an "s" if
+    the number is not 1
+
+    :param num: The number of seconds to convert
+    :type num: float
+    :param word: The word to use for the time unit
+    :type word: str
+    :return: A string with the number of days, hours, minutes, and seconds.
+    """
+    rounded_num = round(num)
+    return f"{rounded_num} {word}{'s' if rounded_num != 1 else ''}"
+
+
+def check_missing_requirements(
+    time_since_creation: timedelta, time_since_join: timedelta
+) -> str:
+    """
+    It takes two `timedelta` objects, and returns a string of the missing requirements for the user to
+    be eligible for the role
+
+    :param time_since_creation: timedelta
+    :type time_since_creation: timedelta
+    :param time_since_join: timedelta = datetime.now() - member.joined_at
+    :type time_since_join: timedelta
+    :return: A string of the missing requirements.
+    """
+    missing_requirements = []
+    if time_since_creation < timedelta(weeks=52):
+        missing_requirements.append(
+            f"{strfdelta((timedelta(weeks=52) - time_since_creation).days/365.25, 'year') if (timedelta(weeks=52) - time_since_creation).days/365.25 >= 1 else ''} {strfdelta((timedelta(weeks=52) - time_since_creation).days % 365.25, 'day')}"
+        )
+    if time_since_join < timedelta(days=30):
+        missing_requirements.append(
+            f"{strfdelta((timedelta(days=30) - time_since_join).days/365.25, 'year') if (timedelta(days=30) - time_since_join).days/365.25 >= 1 else ''} {strfdelta((timedelta(days=30) - time_since_join).days % 365.25, 'day')}"
+        )
+    return ", ".join(missing_requirements)
+
+
+def setup(bot: commands.Bot) -> None:
     bot.add_cog(StaffRequirement(bot))

--- a/cogs/StaffRequirements.py
+++ b/cogs/StaffRequirements.py
@@ -36,12 +36,12 @@ class StaffRequirement(commands.Cog):
         fields=[
             [
                 "Created",
-                f"{account.created_at.strftime('%B %d, %Y')}\n{round(time_since_creation.days/365.25)} year(s), {round(time_since_creation.days % 365.25)} day(s) ago",
+                f"{account.created_at.strftime('%B %d, %Y')}\n{strfdelta(time_since_creation.days/365.25,'year')}, {strfdelta(time_since_creation.days % 365.25, 'day')} ago",
                 True
             ],
             [
                 "Joined",
-                f"{account.joined_at.strftime('%B %d, %Y')}\n{round(time_since_join.days/365.25)} year(s), {round(time_since_join.days % 365.25)} day(s) ago",
+                f"{account.joined_at.strftime('%B %d, %Y')}\n{strfdelta(time_since_join.days/365.25, 'year')}, {strfdelta(time_since_join.days % 365.25, 'day')} ago",
                 True
             ]
         ]
@@ -68,6 +68,9 @@ class StaffRequirement(commands.Cog):
 
         log(f"User {account} checked their requirements in {ctx.guild}.")
 
+def strfdelta(num: float, word: str) -> str:
+    rounded_num = round(num)
+    return f"{rounded_num} {word if rounded_num == 1 else word + 's'}"
 
 def setup(bot) -> None:
     bot.add_cog(StaffRequirement(bot))


### PR DESCRIPTION
Hey, I merged the two embeds into one as suggested in the dev channel, along with a few other cosmetic changes. Here are some screenshots. Any thoughts?

![success](https://user-images.githubusercontent.com/53885408/203135422-b1c5fe52-5569-4ae6-a5d2-fbb3f1e71b68.jpg)
![failure](https://user-images.githubusercontent.com/53885408/203135438-d5093edf-0cc5-4a92-9c49-5af4e17458d5.jpg)

List of changes I've made:
- Combined the two separate embeds into one
- Change the color of the embed to green or red depending on whether the user meets the requirements for staff or not
- If the user meets the requirements, show the staff app link as a button rather than a URL within the embed description. I feel like it's more intuitive for the end user and looks more polished.
- **⚠️ AND AND AND** I changed the logic for how the requirements are checked. Instead of manually computing the join and creation date and year and comparing them as integers, I compare them as `timedelta`'s. Check the comments right above the if-statement. This is a much more readable and much less error-prone approach, as we don't have to check the edge case of the join days being 0 but the years being greater, etc etc etc. Python just checks if the _amount of time_ represented by `time_since_creation` and `time_since_join` are what we'd want.

So, yeah.