### PR TITLE
fix: Gracefully handle multiposts that are quickly deleted

### DIFF
--- a/cogs/Moderation.py
+++ b/cogs/Moderation.py
@@ -240,7 +240,14 @@ class Moderation(commands.Cog):
             ],
         ).build()
 
-        await message.reply(embed=embed)
+        try:
+            await message.reply(embed=embed)
+        except discord.errors.HTTPException as e:
+            if "unknown message".casefold() in repr(e).casefold():
+                # the multiposted message has already been deleted - we can simply ignore this error
+                pass
+            else:
+                raise
 
     @commands.Cog.listener()
     async def on_message(self, message: discord.Message) -> None:


### PR DESCRIPTION
If someone multiposts something, then immediately deletes their message, we get an error when trying to reply to it with the warning:
```
discord.errors.HTTPException: 400 Bad Request (error code: 50035): Invalid Form Body
In message_reference: Unknown message
```

This PR just gracefully handles such an error by `pass`ing when it is raised.