### PR TITLE
fix: Wrong multipost emoji ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,6 @@ To run this bot, you'll need the following .env file in the root directory:
 ```env
 DISCORD_TOKEN = <your discord bot token>
 staff_google_form = <link to the staff google form>
+MULTIPOST_EMOJI = <optional, specify a custom emoji for multiposts e.g. ":multipost:1046975187930849280">
 ALLOW_MULTIPOST_FOR_ROLE = <a role name whose members are immune to multiposting rules>
 ```

--- a/cogs/Moderation.py
+++ b/cogs/Moderation.py
@@ -4,6 +4,7 @@ import time
 from dataclasses import dataclass
 from hashlib import sha256
 from typing import TypeAlias
+import os
 
 import aiohttp
 import discord
@@ -16,7 +17,7 @@ from util.Logging import log
 # hashlib just returns a bytes object, so this allows for slightly stricter typing
 Hash: TypeAlias = bytes
 
-MULTIPOST_EMOJI = ":multipost:1046975245761912873"
+MULTIPOST_EMOJI = os.getenv("MULTIPOST_EMOJI", ":regional_indicator_m:")
 ALLOW_MULTIPOST_FOR_ROLE = os.getenv("ALLOW_MULTIPOST_FOR_ROLE")
 
 

--- a/cogs/Moderation.py
+++ b/cogs/Moderation.py
@@ -4,7 +4,6 @@ import time
 from dataclasses import dataclass
 from hashlib import sha256
 from typing import TypeAlias
-import os
 
 import aiohttp
 import discord
@@ -198,7 +197,7 @@ class Moderation(commands.Cog):
     # deletes recorded fingerprints after 2 minutes,
     # and clears out logged `multipost_warnings` after 10 minutes
     @tasks.loop(seconds=3)
-    async def clear_old_cached_data(self):
+    async def clear_old_cached_data(self) -> None:
         # new messages are always appended to the end of the list
         # so we will only be deleting messages from the front of the list
         # this algorithm finds the number of messages the delete, then deletes them in bulk
@@ -325,7 +324,7 @@ class Moderation(commands.Cog):
         await self.check_multipost(message)
 
     @commands.Cog.listener()
-    async def on_raw_message_delete(self, payload: discord.RawMessageDeleteEvent):
+    async def on_raw_message_delete(self, payload: discord.RawMessageDeleteEvent) -> None:
         if payload.message_id in self.multipost_warnings:
             # The person deleted their message after seeing out multipost warning
             # so we can delete the warning message


### PR DESCRIPTION
#84 added the emoji with the ID 1046975245761912873, which is incorrect.

The correct ID is 1046975187930849280, which you can test by copy pasting `<:multipost:1046975187930849280>` into discord. You'll notice that it will be formatted as the correct emoji.