### PR TITLE
Replace view-db db with csv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,4 +167,4 @@ log.txt
 *.db
 *.sqlit*
 .vscode/
-.csv
+*.csv

--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,4 @@ log.txt
 *.db
 *.sqlit*
 .vscode/
+.csv

--- a/cogs/Alerts.py
+++ b/cogs/Alerts.py
@@ -1,4 +1,5 @@
 import base64
+import csv
 import re
 import sqlite3
 
@@ -266,9 +267,18 @@ class Alerts(commands.Cog):
         :param ctx: commands.Context
         :type ctx: commands.Context
         """
+
+        c = self.db.cursor()
+        c.execute("SELECT * FROM alerts")
+        alerts = c.fetchall()
+        with open("util/alerts.csv", "w") as f:
+            writer = csv.writer(f)
+            writer.writerow(["keyword", "user_id", "user_name"])
+            writer.writerows(alerts)
+
         await ctx.respond(
             content="Alerts Database",
-            file=discord.File("util/database.sqlite"),
+            file=discord.File("util/alerts.csv"),
             ephemeral=True,
         )
 

--- a/cogs/Alerts.py
+++ b/cogs/Alerts.py
@@ -276,9 +276,19 @@ class Alerts(commands.Cog):
             writer.writerow(["keyword", "user_id", "user_name"])
             writer.writerows(alerts)
 
+        c.execute("SELECT * FROM messagecount")
+        messagecount = c.fetchall()
+        with open("util/messagecount.csv", "w") as f:
+            writer = csv.writer(f)
+            writer.writerow(["user_id", "message_count"])
+            writer.writerows(messagecount)
+
         await ctx.respond(
-            content="Alerts Database",
-            file=discord.File("util/alerts.csv"),
+            content="Database",
+            files=[
+                discord.File("util/alerts.csv"),
+                discord.File("util/messagecount.csv"),
+            ],
             ephemeral=True,
         )
 


### PR DESCRIPTION
- For ease of accessibility, users will now receive a CSV file instead of a .SQLITE file when calling the Alerts table.
- Addresses #90 