### PR TITLE
!IMPORTANT! Hotfixed security issue

### DIFF
--- a/cogs/Alerts.py
+++ b/cogs/Alerts.py
@@ -267,7 +267,11 @@ class Alerts(commands.Cog):
         :param ctx: commands.Context
         :type ctx: commands.Context
         """
-
+        #TODO: remove hardcode and implement permanent fix
+        CODEOWNERS = [279614239679971328, 882779998782636042, 154670542237073419, 74576452854480896] # Hardcoded only as hotfix (shuler, spencer, rust, czar)
+        if ctx.author.id not in CODEOWNERS:
+            await ctx.respond(content="Not allowed", ephemeral=True)
+            return
         c = self.db.cursor()
         c.execute("SELECT * FROM alerts")
         alerts = c.fetchall()


### PR DESCRIPTION
All users were able to access the /view-db command and get full access to the entire database(s)

This was solved by restricting the command to staff role only in the server settings themselves.
This does not work because anyone can invite the bot to their own server and use the command with no restrictions.

Even though the invite link is not public anyone can get the link by doing:
```
https://discord.com/oauth2/authorize?client_id=BOTID&permissions=8&scope=applications.commands%20bot
and just replacing the BOTID with Pax Academia's ID (1033864301045362699)
```

This hotfix temporarily fixes the command by only allowing 4 people access to the command. A better fix needs to be implemented in the future, but the bot needs to be back online as soon as possible.