### PR TITLE
Improved database submission upon /view-db

### DIFF
--- a/cogs/Alerts.py
+++ b/cogs/Alerts.py
@@ -11,8 +11,10 @@ from util.EmbedBuilder import EmbedBuilder
 from util.Logging import log
 
 # used to encode/ decode user input to protect against SQLi
-b64ify = lambda x: base64.b64encode(x.encode()).decode()
-deb64ify = lambda y: base64.b64decode(y.encode()).decode()
+
+
+def b64ify(x): return base64.b64encode(x.encode()).decode()
+def deb64ify(y): return base64.b64decode(y.encode()).decode()
 
 
 def get_keywords(ctx: discord.AutocompleteContext) -> list:
@@ -267,8 +269,9 @@ class Alerts(commands.Cog):
         :param ctx: commands.Context
         :type ctx: commands.Context
         """
-        #TODO: remove hardcode and implement permanent fix
-        CODEOWNERS = [279614239679971328, 882779998782636042, 154670542237073419, 74576452854480896, 198067816245624833] # Hardcoded only as hotfix (shuler, spencer, rust, czar)
+        # TODO: remove hardcode and implement permanent fix
+        CODEOWNERS = [279614239679971328, 882779998782636042, 154670542237073419, 74576452854480896,
+                      198067816245624833]  # Hardcoded only as hotfix (shuler, spencer, rust, czar)
         if ctx.author.id not in CODEOWNERS:
             await ctx.respond(content="Not allowed", ephemeral=True)
             return
@@ -294,6 +297,7 @@ class Alerts(commands.Cog):
                 writer.writerow(column_names)
                 writer.writerows(content)
 
+        # assumption that there are <10 different tables
         await ctx.respond(
             content="Databases",
             files=[discord.File(f"util/{table}.csv") for table in table_names],

--- a/cogs/Alerts.py
+++ b/cogs/Alerts.py
@@ -13,8 +13,12 @@ from util.Logging import log
 # used to encode/ decode user input to protect against SQLi
 
 
-def b64ify(x): return base64.b64encode(x.encode()).decode()
-def deb64ify(y): return base64.b64decode(y.encode()).decode()
+def b64ify(x: str) -> str:
+    return base64.b64encode(x.encode()).decode()
+
+
+def deb64ify(y: str) -> str:
+    return base64.b64decode(y.encode()).decode()
 
 
 def get_keywords(ctx: discord.AutocompleteContext) -> list:
@@ -270,20 +274,27 @@ class Alerts(commands.Cog):
         :type ctx: commands.Context
         """
         # TODO: remove hardcode and implement permanent fix
-        CODEOWNERS = [279614239679971328, 882779998782636042, 154670542237073419, 74576452854480896,
-                      198067816245624833]  # Hardcoded only as hotfix (shuler, spencer, rust, czar)
+        CODEOWNERS = [
+            279614239679971328,
+            882779998782636042,
+            154670542237073419,
+            74576452854480896,
+            198067816245624833,
+        ]  # Hardcoded only as hotfix (shuler, spencer, rust, czar)
         if ctx.author.id not in CODEOWNERS:
             await ctx.respond(content="Not allowed", ephemeral=True)
             return
 
         c = self.db.cursor()
-        c.execute("""SELECT 
+        c.execute(
+            """SELECT 
                         name
                     FROM 
                         sqlite_schema
                     WHERE 
                         type ='table' AND 
-                        name NOT LIKE 'sqlite_%'""")
+                        name NOT LIKE 'sqlite_%'"""
+        )
         table_names = [x[0] for x in c.fetchall()]
 
         for table in table_names:


### PR DESCRIPTION
This PR removes (part) of the hard-coding in /view-db.
Before, every table was hard coded, turned into a csv file and uploaded. These changes make this command future-proof (up to 10 tables) so that no changes need to be made when (eventually) more tables will be added to the database.