### PR TITLE
fix: Don't delete the warning immediately after sending it

### DIFF
--- a/cogs/Moderation.py
+++ b/cogs/Moderation.py
@@ -303,8 +303,8 @@ class Moderation(commands.Cog):
                 await message.add_reaction(MULTIPOST_EMOJI)
 
                 warning = await message.reply(embed=embed)
-                self.multipost_warnings[message.id] = (warning, fingerprint)
                 await self.delete_previous_multipost_warnings(fingerprint.channel_id, fingerprint.author_id)
+                self.multipost_warnings[message.id] = (warning, fingerprint)
             except discord.errors.HTTPException as e:
                 if "unknown message".casefold() in repr(e).casefold():
                     # The multipost has already been deleted, take no action


### PR DESCRIPTION
`delete_previous_multipost_warnings` looks at `self.multipost_warnings` and deletes any messages that match the same fingerprint. This will include the warning that was just sent. This PR simply moves the deletion above the new warning's addition to `self.multipost_warnings`, so that it will not get deleted.