### PR TITLE
Fix: `re.error: nothing to repeat at position 0`

### DIFF
--- a/cogs/Alerts.py
+++ b/cogs/Alerts.py
@@ -164,7 +164,7 @@ class Alerts(commands.Cog):
             c.execute("SELECT * FROM alert")
             keywords = c.fetchall()
             if not any(
-                re.search(keyword[2], message.content, re.IGNORECASE)
+                re.search(re.escape(keyword[2]), message.content, re.IGNORECASE)
                 for keyword in keywords
             ):
                 return


### PR DESCRIPTION
The error "re.error: nothing to repeat at position 0" is typically caused by a special character in the regular expression that needs to be escaped. the issue is likely with the regular expression `keyword[2]`.