### PR TITLE
Fix codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,1 @@
-@Arborym/main
-@sebastiaan-daniels/main
-@woseek/main
+* @Arborym @sebastiaan-daniels @woseek


### PR DESCRIPTION
I'm pretty sure our syntax for codeowners has been incorrect for the duration of this file's existence. I changed it so that all PRs will automatically request reviews from the specified users.