### PR TITLE
Bugfix: Incorrect logging

### DIFF
--- a/cogs/StaffAppsUser.py
+++ b/cogs/StaffAppsUser.py
@@ -371,7 +371,6 @@ class StaffAppView(discord.ui.View):
         """
         Sends a modal with the next questions
         """
-        Log(f"{self.author} has completed the Staff Application")
         await interaction.response.send_modal(
             StaffAppModal(
                 self.author,
@@ -473,6 +472,7 @@ class StaffAppModal(discord.ui.Modal):
             color=0xFFD700,
         )
         await interaction.response.edit_message(embed=embed, content="", view=None)
+        Log(f"{self.author} has completed the Staff Application")
 
 
 class StaffAppsUser(commands.Cog):


### PR DESCRIPTION
During a routine checkup of the logfiles and db integrity, The count of successful applications was higher than the count(*) of applications in the database. After investigating I found it was due to incorrect placing of the log message in the source code.

(The application would already be logged as submitted when the user pressed the button to go to the next questions)