### PR TITLE
chore: upgrade `undetected-chromedriver` to 3.5.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ pubchempy==1.0.4
 py-cord==2.4.1
 python-dotenv==1.0.0
 selenium==4.10.0
-undetected-chromedriver==3.4.7
+undetected-chromedriver==3.5.0
 wikipedia==1.4.0


### PR DESCRIPTION
because it contains [this fix](https://github.com/ultrafunkamsterdam/undetected-chromedriver/commit/2b035b4ea1d88224abd570b187f16094663462a3#diff-b1415858986f3be41e64bac68e30d09ac7a9713f92af3a2177bbd193e8393bc2) for [this error](https://discord.com/channels/238956364729155585/1040360228388098159/1115913795102068747)