### PR TITLE
Safety/Enhancement: Add ability to limit users

### DIFF
--- a/cogs/Alerts.py
+++ b/cogs/Alerts.py
@@ -146,7 +146,9 @@ class Alerts(commands.Cog):
         Log(f"Alert removed by $ in {ctx.guild}.", ctx.author)
 
     @commands.slash_command(name="alerts-list", description="Lists all alerts.")
-    @limit(3) # User should still be allowed to remove their alerts if they have too many
+    @limit(
+        3
+    )  # User should still be allowed to remove their alerts if they have too many
     async def list_alerts(self, ctx: ApplicationContext) -> None:
         """
         It gets all alerts from the database and responds with a list of them

--- a/cogs/Alerts.py
+++ b/cogs/Alerts.py
@@ -8,7 +8,7 @@ from discord.commands.context import ApplicationContext
 from discord.ext import commands
 
 from util.EmbedBuilder import EmbedBuilder
-from util.Logging import Log
+from util.Logging import Log, limit
 
 
 def get_keywords(ctx: discord.AutocompleteContext) -> list[str]:
@@ -45,6 +45,7 @@ class Alerts(commands.Cog):
         name="alerts-add",
         description="Adds an alert for a keyword.",
     )
+    @limit(1)
     async def add_alert(self, ctx: ApplicationContext, keyword: str) -> None:
         """
         Checks if the keyword is already in the database, if it is, sends an error message, if it
@@ -106,6 +107,7 @@ class Alerts(commands.Cog):
         description="The keyword to remove.",
         autocomplete=get_keywords,
     )
+    @limit(1)
     async def remove_alert(self, ctx: ApplicationContext, keyword: str) -> None:
         """
         It removes an alert from the database.
@@ -144,6 +146,7 @@ class Alerts(commands.Cog):
         Log(f"Alert removed by $ in {ctx.guild}.", ctx.author)
 
     @commands.slash_command(name="alerts-list", description="Lists all alerts.")
+    @limit(3) # User should still be allowed to remove their alerts if they have too many
     async def list_alerts(self, ctx: ApplicationContext) -> None:
         """
         It gets all alerts from the database and responds with a list of them

--- a/cogs/DeepL.py
+++ b/cogs/DeepL.py
@@ -5,7 +5,7 @@ from discord import option
 from discord.ext import commands
 
 from util.EmbedBuilder import EmbedBuilder
-from util.Logging import Log
+from util.Logging import Log, limit
 
 LANGUAGES = [
     "Bulgarian",
@@ -106,6 +106,7 @@ class Translation(commands.Cog):
         required=False,
         choices=FORMALITY_TONES,
     )
+    @limit(2)
     async def translate(
         self,
         ctx: commands.Context,

--- a/cogs/DetectAI.py
+++ b/cogs/DetectAI.py
@@ -16,7 +16,7 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.wait import WebDriverWait
 
 from util.EmbedBuilder import EmbedBuilder
-from util.Logging import Log
+from util.Logging import Log, limit
 
 
 class AuthorPredication(Enum):
@@ -287,6 +287,7 @@ class AI(commands.Cog):
         description="The text to run through the AI.",
         required=True,
     )
+    @limit(2)
     async def ai(self, ctx: ApplicationContext, text: str) -> None:
         """
         Runs a given text through an AI detector and returns the result as an image.

--- a/cogs/Dictionary.py
+++ b/cogs/Dictionary.py
@@ -11,7 +11,7 @@ from discord.commands.context import ApplicationContext
 from discord.ext import commands
 
 from util.EmbedBuilder import EmbedBuilder
-from util.Logging import Log
+from util.Logging import Log, limit
 
 
 @dataclass
@@ -498,6 +498,7 @@ class Dictionary(commands.Cog):
 
     @commands.slash_command(name="define", description="Defines a word.")
     @option("word", str, description="The word to define.", required=True)
+    @limit(2)
     async def define(self, ctx: ApplicationContext, word: str) -> None:
         """
         It takes a word as an argument, and returns the definition of that word

--- a/cogs/Misc.py
+++ b/cogs/Misc.py
@@ -151,7 +151,7 @@ class Misc(commands.Cog):
         guild_ids=None if DUMP_GUILD is None else [DUMP_GUILD],
         guild_only=DUMP_GUILD is not None,
     )
-    @limit(1) #db access
+    @limit(1)  # db access
     async def dump_database(self, ctx: ApplicationContext) -> None:
         """
         It dumps the database to a csv file and sends it to the user

--- a/cogs/Misc.py
+++ b/cogs/Misc.py
@@ -10,7 +10,7 @@ from discord.commands.context import ApplicationContext
 from discord.ext import commands
 from discord.interactions import Interaction
 
-from util.Logging import Log
+from util.Logging import Log, limit
 
 DATABASE_FILES = [
     "util/database.sqlite",
@@ -112,6 +112,7 @@ class Misc(commands.Cog):
         self.bot = bot
 
     @commands.slash_command(name="ping", description="Pings the bot.")
+    @limit(3)
     async def ping(self, ctx: ApplicationContext) -> None:
         """
         It sends a message, then edits that message to say "Pong!" and the latency of the bot
@@ -150,6 +151,7 @@ class Misc(commands.Cog):
         guild_ids=None if DUMP_GUILD is None else [DUMP_GUILD],
         guild_only=DUMP_GUILD is not None,
     )
+    @limit(1) #db access
     async def dump_database(self, ctx: ApplicationContext) -> None:
         """
         It dumps the database to a csv file and sends it to the user

--- a/cogs/PubChem.py
+++ b/cogs/PubChem.py
@@ -5,7 +5,7 @@ from discord import option
 from discord.ext import commands
 
 from util.EmbedBuilder import EmbedBuilder
-from util.Logging import Log
+from util.Logging import Log, limit
 
 
 def get_data(name: str) -> dict:
@@ -54,6 +54,7 @@ class PubChem(commands.Cog):
         description="The name of the compound to be searched.",
         required=True,
     )
+    @limit(2)
     async def pubchem(self, ctx: commands.Context, name: str) -> None:
         """
         It takes a string, searches for it on PubChem, and returns a Discord embed with the results

--- a/cogs/Rules.py
+++ b/cogs/Rules.py
@@ -3,7 +3,7 @@ from discord.commands import option
 from discord.ext import commands
 
 from util.EmbedBuilder import EmbedBuilder
-from util.Logging import Log
+from util.Logging import Log, limit
 
 rules = {
     "Rule A): Respect": "Maintain civility and conduct yourself appropriately. Avoid derogatory language, discriminatory jokes, and hate speech.",
@@ -39,6 +39,7 @@ class Rules(commands.Cog):
         choices=get_rules(),
     )
     @option("user", discord.User, description="The user to ping.", required=False)
+    @limit(3)
     async def rule(self, ctx: commands.Context, rule: str, user: discord.User) -> None:
         embed = EmbedBuilder(title=rule, description=rules[rule]).build()
 

--- a/cogs/StaffAppsBackoffice.py
+++ b/cogs/StaffAppsBackoffice.py
@@ -10,7 +10,7 @@ from discord import option
 from discord.ext import commands
 
 from util.EmbedBuilder import EmbedBuilder
-from util.Logging import Log
+from util.Logging import Log, limit
 
 
 class staffAppsSeeAll(discord.ui.View):
@@ -777,6 +777,7 @@ class StaffAppsBackoffice(commands.Cog):
         description="The specific application ID to check. IGNORES SUBCOMMAND",
         required=False,
     )
+    @limit(1)
     async def see_apps(
         self,
         ctx: commands.Context,

--- a/cogs/StaffAppsUser.py
+++ b/cogs/StaffAppsUser.py
@@ -10,7 +10,7 @@ from discord.ext import commands
 from humanize import precisedelta
 
 from util.EmbedBuilder import EmbedBuilder
-from util.Logging import Log
+from util.Logging import Log, limit
 
 
 class embeds:
@@ -515,6 +515,7 @@ class StaffAppsUser(commands.Cog):
         name="apply-for-staff",
         description="Apply for a staff position if your account meets the requirements!",
     )
+    @limit(1)
     async def apply(self, ctx: commands.Context) -> None:
         """
         Lets users apply for staff positions

--- a/cogs/Surveys.py
+++ b/cogs/Surveys.py
@@ -51,9 +51,12 @@ class Surveys(commands.Cog):
                                 embed=embed,
                             )
         await self.bot.process_commands(message)
-        Log(
-            f" $ sent a survey in {message.channel.name}, bot responded", message.author
-        )
+        try:
+            Log(
+                f" $ sent a survey in {message.channel.name}, bot responded", message.author
+            )
+        except AttributeError:
+            pass # WHY??? This error happens when a user is limited with the @limited wrapper?
 
 
 def setup(bot: commands.Bot) -> None:

--- a/cogs/Surveys.py
+++ b/cogs/Surveys.py
@@ -53,10 +53,11 @@ class Surveys(commands.Cog):
         await self.bot.process_commands(message)
         try:
             Log(
-                f" $ sent a survey in {message.channel.name}, bot responded", message.author
+                f" $ sent a survey in {message.channel.name}, bot responded",
+                message.author,
             )
         except AttributeError:
-            pass # WHY??? This error happens when a user is limited with the @limited wrapper?
+            pass  # WHY??? This error happens when a user is limited with the @limited wrapper?
 
 
 def setup(bot: commands.Bot) -> None:

--- a/cogs/Tips.py
+++ b/cogs/Tips.py
@@ -3,7 +3,7 @@ from discord.commands.context import ApplicationContext
 from discord.ext import commands
 
 from util.EmbedBuilder import EmbedBuilder
-from util.Logging import Log
+from util.Logging import Log, limit
 
 TIPS = {
     "Ask Your Question": (
@@ -73,6 +73,7 @@ class Tips(commands.Cog):
         choices=["Yes", "No"],
         required=False,
     )
+    @limit(3)
     async def tip(
         self,
         ctx: ApplicationContext,

--- a/cogs/Wikipedia.py
+++ b/cogs/Wikipedia.py
@@ -4,7 +4,7 @@ import wikipedia
 from discord.ext import commands
 
 from util.EmbedBuilder import EmbedBuilder
-from util.Logging import Log
+from util.Logging import Log, limit
 
 
 def get_wiki_without_logging(query: str) -> dict[str, str]:
@@ -33,6 +33,7 @@ class Wikipedia(commands.Cog):
         self.bot = bot
 
     @commands.slash_command(name="wiki", description="Searches Wikipedia for a topic.")
+    @limit(2)
     async def wiki(self, ctx: commands.Context, query: str) -> None:
         """
         It searches Wikipedia for a query and returns the first result

--- a/util/ERD.mdj
+++ b/util/ERD.mdj
@@ -205,13 +205,30 @@
 											"height": 13,
 											"text": "helpMessagesSent INT Nna",
 											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLAttributeView",
+											"_id": "AAAAAAGI+e6i7PidNu0=",
+											"_parent": {
+												"$ref": "AAAAAAGG5UQbbghK7p8="
+											},
+											"model": {
+												"$ref": "AAAAAAGI+e6i4/iadYI="
+											},
+											"font": "Arial;13;0",
+											"left": 389,
+											"top": 217,
+											"width": 162.58251953125,
+											"height": 13,
+											"text": "limitLevel INT",
+											"horizontalAlignment": 0
 										}
 									],
 									"font": "Arial;13;0",
 									"left": 384,
 									"top": 137,
 									"width": 172.58251953125,
-									"height": 83
+									"height": 98
 								},
 								{
 									"_type": "UMLOperationCompartmentView",
@@ -267,7 +284,7 @@
 							"left": 384,
 							"top": 112,
 							"width": 172.58251953125,
-							"height": 108,
+							"height": 123,
 							"showVisibility": false,
 							"nameCompartment": {
 								"$ref": "AAAAAAGG5UQbbQhF1V4="
@@ -1659,8 +1676,8 @@
 										"$ref": "AAAAAAGG5WuEKw1j4MU="
 									},
 									"font": "Arial;13;0",
-									"left": 312,
-									"top": 234,
+									"left": 314,
+									"top": 237,
 									"width": 24.2099609375,
 									"height": 13,
 									"alpha": 1.5707963267948966,
@@ -1682,8 +1699,8 @@
 									},
 									"visible": null,
 									"font": "Arial;13;0",
-									"left": 316,
-									"top": 221,
+									"left": 318,
+									"top": 224,
 									"height": 13,
 									"alpha": 1.5707963267948966,
 									"distance": 30,
@@ -1704,7 +1721,7 @@
 									"visible": false,
 									"font": "Arial;13;0",
 									"left": 341,
-									"top": 259,
+									"top": 262,
 									"height": 13,
 									"alpha": -1.5707963267948966,
 									"distance": 15,
@@ -1724,7 +1741,7 @@
 									},
 									"visible": false,
 									"font": "Arial;13;0",
-									"left": 295,
+									"left": 299,
 									"top": 254,
 									"height": 13,
 									"alpha": 0.5235987755982988,
@@ -1745,8 +1762,8 @@
 									},
 									"visible": false,
 									"font": "Arial;13;0",
-									"left": 290,
-									"top": 241,
+									"left": 294,
+									"top": 242,
 									"height": 13,
 									"alpha": 0.7853981633974483,
 									"distance": 40,
@@ -1765,8 +1782,8 @@
 										"$ref": "AAAAAAGG5WuEKw1krXE="
 									},
 									"font": "Arial;13;0",
-									"left": 297,
-									"top": 279,
+									"left": 300,
+									"top": 280,
 									"width": 19.5126953125,
 									"height": 13,
 									"alpha": -0.5235987755982988,
@@ -1787,8 +1804,8 @@
 										"$ref": "AAAAAAGG5WuEKw1liVw="
 									},
 									"font": "Arial;13;0",
-									"left": 341,
-									"top": 215,
+									"left": 339,
+									"top": 220,
 									"width": 29.275390625,
 									"height": 13,
 									"alpha": -0.5235987755982988,
@@ -1809,8 +1826,8 @@
 									},
 									"visible": false,
 									"font": "Arial;13;0",
-									"left": 345,
-									"top": 205,
+									"left": 344,
+									"top": 210,
 									"height": 13,
 									"alpha": -0.7853981633974483,
 									"distance": 40,
@@ -1829,8 +1846,8 @@
 									},
 									"visible": false,
 									"font": "Arial;13;0",
-									"left": 373,
-									"top": 236,
+									"left": 371,
+									"top": 242,
 									"height": 13,
 									"alpha": 0.5235987755982988,
 									"distance": 25,
@@ -1875,7 +1892,7 @@
 								"$ref": "AAAAAAGG5WmpKgtPVb8="
 							},
 							"lineStyle": 1,
-							"points": "282:287;385:220",
+							"points": "285:287;383:226",
 							"nameLabel": {
 								"$ref": "AAAAAAGG5WuELA1oLAQ="
 							},
@@ -2203,8 +2220,8 @@
 										"$ref": "AAAAAAGG5W2Nshn13g8="
 									},
 									"font": "Arial;13;0",
-									"left": 544,
-									"top": 245,
+									"left": 547,
+									"top": 253,
 									"width": 24.2099609375,
 									"height": 13,
 									"alpha": 1.5707963267948966,
@@ -2226,8 +2243,8 @@
 									},
 									"visible": null,
 									"font": "Arial;13;0",
-									"left": 568,
-									"top": 236,
+									"left": 571,
+									"top": 243,
 									"height": 13,
 									"alpha": 1.5707963267948966,
 									"distance": 30,
@@ -2247,8 +2264,8 @@
 									},
 									"visible": false,
 									"font": "Arial;13;0",
-									"left": 533,
-									"top": 264,
+									"left": 536,
+									"top": 272,
 									"height": 13,
 									"alpha": -1.5707963267948966,
 									"distance": 15,
@@ -2267,8 +2284,8 @@
 										"$ref": "AAAAAAGG5W2Nshn2rrA="
 									},
 									"font": "Arial;13;0",
-									"left": 526,
-									"top": 225,
+									"left": 534,
+									"top": 239,
 									"width": 29.275390625,
 									"height": 13,
 									"alpha": 0.5235987755982988,
@@ -2290,8 +2307,8 @@
 									},
 									"visible": false,
 									"font": "Arial;13;0",
-									"left": 552,
-									"top": 218,
+									"left": 559,
+									"top": 232,
 									"height": 13,
 									"alpha": 0.7853981633974483,
 									"distance": 40,
@@ -2311,8 +2328,8 @@
 									},
 									"visible": false,
 									"font": "Arial;13;0",
-									"left": 516,
-									"top": 238,
+									"left": 524,
+									"top": 253,
 									"height": 13,
 									"alpha": -0.5235987755982988,
 									"distance": 25,
@@ -2332,7 +2349,7 @@
 									},
 									"visible": false,
 									"font": "Arial;13;0",
-									"left": 573,
+									"left": 571,
 									"top": 267,
 									"height": 13,
 									"alpha": -0.5235987755982988,
@@ -2352,7 +2369,7 @@
 									},
 									"visible": false,
 									"font": "Arial;13;0",
-									"left": 582,
+									"left": 579,
 									"top": 257,
 									"height": 13,
 									"alpha": -0.7853981633974483,
@@ -2371,8 +2388,8 @@
 										"$ref": "AAAAAAGG5W2Nshn3Ri0="
 									},
 									"font": "Arial;13;0",
-									"left": 545,
-									"top": 287,
+									"left": 543,
+									"top": 288,
 									"width": 19.5126953125,
 									"height": 13,
 									"alpha": 0.5235987755982988,
@@ -2419,7 +2436,7 @@
 								"$ref": "AAAAAAGG5UQbbQhELhw="
 							},
 							"lineStyle": 1,
-							"points": "513:220;578:303",
+							"points": "520:235;576:303",
 							"nameLabel": {
 								"$ref": "AAAAAAGG5W2Nsxn6pVg="
 							},
@@ -2521,7 +2538,8 @@
 							"_parent": {
 								"$ref": "AAAAAAGG5UQbbAhC134="
 							},
-							"name": "markedSpam BOOL Nna"
+							"name": "markedSpam BOOL Nna",
+							"type": ""
 						},
 						{
 							"_type": "UMLAttribute",
@@ -2538,7 +2556,16 @@
 							"_parent": {
 								"$ref": "AAAAAAGG5UQbbAhC134="
 							},
-							"name": "helpMessagesSent INT Nna"
+							"name": "helpMessagesSent INT Nna",
+							"type": ""
+						},
+						{
+							"_type": "UMLAttribute",
+							"_id": "AAAAAAGI+e6i4/iadYI=",
+							"_parent": {
+								"$ref": "AAAAAAGG5UQbbAhC134="
+							},
+							"name": "limitLevel INT"
 						}
 					]
 				},

--- a/util/Logging.py
+++ b/util/Logging.py
@@ -61,8 +61,7 @@ def limit(_limit_level: int) -> callable:
                     )
                     return
 
-            result = await func(*args, **kwargs)
-            return result
+            return await func(*args, **kwargs)
 
         return wrapper
 

--- a/util/Logging.py
+++ b/util/Logging.py
@@ -3,6 +3,57 @@
 import datetime
 import discord
 import re
+import sqlite3
+import functools
+from util.EmbedBuilder import EmbedBuilder
+
+
+def limit(_limit_level: int) -> callable:
+    """
+    Limit levels:
+    None: No limit
+    1: Cannot use database commands (I.e alerts & applications)
+    2: Cannot use pax non help specific commands (I.e. chemsearch, define, wiki, ...)
+    3: Cannot use pax. (ping, rule, tip...)
+    Levels are inclusive, so if you are level 2, you cannot use level 1 commands either.
+    """
+
+    def decorator(func: callable) -> callable:
+        @functools.wraps(func)
+        async def wrapper(*args, **kwargs) -> callable:
+            """
+            Wrapper to determine if the user is limited or not.
+            """
+
+            # Get the author id
+            author_id = None
+            for arg in args:
+                try:
+                    author_id = arg.author.id
+                    ctx = arg
+                except AttributeError:  # Type is not a context
+                    continue
+
+            if author_id is not None:  # if no author exists, then we cannot limit, return func instead
+                conn = sqlite3.connect("util/database.sqlite")
+                c = conn.cursor()
+                limit_level = c.execute("SELECT limitLevel from user where uid = ?", (author_id,)).fetchone()[
+                    0] or 0  # if no limit level exists, then it is 0
+                if limit_level >= _limit_level:
+                    embed = EmbedBuilder(
+                        title="You cannot use this command!",
+                        description="You are limited from using this command! Please contact a moderator if you believe this is a mistake.",
+                        color=0xFF0000,
+                    ).build()
+                    await ctx.respond(embed=embed, ephemeral=True)
+                    Log(
+                        f"$ tried to use {ctx.command.name}. But is limited from using it.", ctx.author)
+                    return
+
+            result = await func(*args, **kwargs)
+            return result
+        return wrapper
+    return decorator
 
 
 class Log:

--- a/util/Logging.py
+++ b/util/Logging.py
@@ -59,7 +59,7 @@ def limit(_limit_level: int) -> callable:
                         f"$ tried to use {ctx.command.name}. But is limited from using it.",
                         ctx.author,
                     )
-                    return
+                    return None
 
             return await func(*args, **kwargs)
 

--- a/util/Logging.py
+++ b/util/Logging.py
@@ -70,7 +70,7 @@ def limit(_limit_level: int) -> callable:
 
 
 class Log:
-    def __init__(self, message: str, user: discord.User = None) -> None:
+    def __init__(self, message: str, user: discord.User | None = None) -> None:
         """
         Basic logging module.
         If a message and a user is given, Will replace $ in message with the user's name,

--- a/util/Logging.py
+++ b/util/Logging.py
@@ -1,10 +1,12 @@
 # !SKA#0001 24/10/2022
 
 import datetime
-import discord
+import functools
 import re
 import sqlite3
-import functools
+
+import discord
+
 from util.EmbedBuilder import EmbedBuilder
 
 

--- a/util/Logging.py
+++ b/util/Logging.py
@@ -43,7 +43,8 @@ def limit(_limit_level: int) -> callable:
                 c = conn.cursor()
                 limit_level = (
                     c.execute(
-                        "SELECT limitLevel from user where uid = ?", (author_id,)
+                        "SELECT limitLevel from user where uid = ?",
+                        (author_id,),
                     ).fetchone()[0]
                     or 0
                 )  # if no limit level exists, then it is 0
@@ -89,7 +90,9 @@ class Log:
                     user_name = f"{user.name}#{user.discriminator}"
 
                 message = re.sub(
-                    r"(?<!\/)\$", user_name, message
+                    r"(?<!\/)\$",
+                    user_name,
+                    message,
                 )  # replaces $ in string to new username
 
             log_file.write(f"{now_str} - {message}\n")

--- a/util/Logging.py
+++ b/util/Logging.py
@@ -34,11 +34,17 @@ def limit(_limit_level: int) -> callable:
                 except AttributeError:  # Type is not a context
                     continue
 
-            if author_id is not None:  # if no author exists, then we cannot limit, return func instead
+            if (
+                author_id is not None
+            ):  # if no author exists, then we cannot limit, return func instead
                 conn = sqlite3.connect("util/database.sqlite")
                 c = conn.cursor()
-                limit_level = c.execute("SELECT limitLevel from user where uid = ?", (author_id,)).fetchone()[
-                    0] or 0  # if no limit level exists, then it is 0
+                limit_level = (
+                    c.execute(
+                        "SELECT limitLevel from user where uid = ?", (author_id,)
+                    ).fetchone()[0]
+                    or 0
+                )  # if no limit level exists, then it is 0
                 if limit_level >= _limit_level:
                     embed = EmbedBuilder(
                         title="You cannot use this command!",
@@ -47,12 +53,16 @@ def limit(_limit_level: int) -> callable:
                     ).build()
                     await ctx.respond(embed=embed, ephemeral=True)
                     Log(
-                        f"$ tried to use {ctx.command.name}. But is limited from using it.", ctx.author)
+                        f"$ tried to use {ctx.command.name}. But is limited from using it.",
+                        ctx.author,
+                    )
                     return
 
             result = await func(*args, **kwargs)
             return result
+
         return wrapper
+
     return decorator
 
 

--- a/util/db_builder.py
+++ b/util/db_builder.py
@@ -17,7 +17,8 @@ c.execute(
     messagesSent INTEGER NOT NULL,
     markedSpam BOOLEAN NOT NULL,
     cooldown varchar(100),
-    helpMessagesSent INTEGER NOT NULL
+    helpMessagesSent INTEGER NOT NULL,
+    limitLevel INTEGER
     );
     """,
 )

--- a/util/db_update.py
+++ b/util/db_update.py
@@ -14,7 +14,7 @@ Alter table to include a new column
 c.execute(
     """
 ALTER TABLE user
-ADD helpMessagesSent INTEGER NOT NULL DEFAULT 0
+ADD limitLevel INTEGER
 """
 )
 


### PR DESCRIPTION
Because some people [don't know how to behave](https://discord.com/channels/238956364729155585/238956364729155585/1092872600331501609), The ability to limit specific users from using (parts) of the bot has been implemented.

This feature does **not** serve as a substitute to normal moderation, and will _only_ be used in case of bot abuse. Reasons for this could be:
- Setting up alerts to spam the bot
- trying to abuse rate limits of other sites
- trying to manipulate the db in malicious ways

A user can be limited in 3 different ways:
- User is limited from interacting with the database
- User is limited from db & all commands that require internet
- User is fully limited from any & all commands

closes #186 