### PR TITLE
Hotfix: Add limitLevel in addUser()

### DIFF
--- a/cogs/MessageCounter.py
+++ b/cogs/MessageCounter.py
@@ -60,8 +60,8 @@ class MessageCounter(commands.Cog):
 
     def add_user(self, uid: int) -> None:
         self.cursor.execute(
-            "INSERT INTO user VALUES (?, ?, ?, ?, ?)",
-            (uid, 0, False, None, 0),
+            "INSERT INTO user VALUES (?, ?, ?, ?, ?, ?)",
+            (uid, 0, False, None, 0, None),
         )  # See ERD.mdj
 
     def update_user(self, uid: int, amount: int) -> None:


### PR DESCRIPTION
The user table was updated in the db, This needs to be reflected when a user is added.