### PR TITLE
Add ability to give feedback on experimental commands

### DIFF
--- a/util/dev.py
+++ b/util/dev.py
@@ -108,7 +108,7 @@ def experimental(func):
 
     @experimental
     async def function():
-        return tuple[ctx,embed,ephemeral]
+        return tuple[ctx | message,embed,ephemeral]
 
     Instead of responding to the user, return your response in a tuple.
     This wrapper will send the response and add the view.
@@ -119,7 +119,14 @@ def experimental(func):
         Wrapper to add a feedback view
         """
         r = await func(*args, **kwargs)
-        await r[0].respond(content=r[1], ephemeral=r[2], view=feedback(r[0].author, func.__name__))
+
+        if r is None:
+            return r
+
+        if isinstance(r[0], discord.ApplicationContext):
+            await r[0].respond(content=r[1], ephemeral=r[2], view=feedback(r[0].author, func.__name__))
+        elif isinstance(r[0], discord.Message):
+            await r[0].channel.send(content=r[1], view=feedback(r[0].author, func.__name__))
         return r
     return wrapper
 

--- a/util/dev.py
+++ b/util/dev.py
@@ -15,10 +15,10 @@ from time import time
 
 ALLOWED_ROLES = [  # This is ok to be harcoded
     1040358438242365490,  # pax
-    892124929590431815, # VH
-    267486666292199435, # VC
-    319948173554745345, # EC
-    410350754180890624, # Guide
+    892124929590431815,  # VH
+    267486666292199435,  # VC
+    319948173554745345,  # EC
+    410350754180890624,  # Guide
     267474828863340545  # Mod
 ]
 
@@ -28,7 +28,7 @@ class feedback(discord.ui.View):
         super().__init__()
         self.author = author
         self.func_name = func_name
-        
+
     @discord.ui.button(
         label="",
         style=discord.ButtonStyle.green,
@@ -80,7 +80,8 @@ class feedback(discord.ui.View):
         c = db.cursor()
         c.execute(
             "INSERT INTO feedback VALUES (?, ?, ?, ?, ?, ?)",
-            (None, time(), self.author.id, self.func_name, like, interaction.message.jump_url),
+            (None, time(), self.author.id, self.func_name,
+             like, interaction.message.jump_url),
         )
         db.commit()
         db.close()
@@ -143,5 +144,5 @@ def experimental(func):
 
 
 if 'a':
-#if __name__ != "__main__":
+    # if __name__ != "__main__":
     database()

--- a/util/dev.py
+++ b/util/dev.py
@@ -143,6 +143,5 @@ def experimental(func):
     return wrapper
 
 
-if 'a':
-    # if __name__ != "__main__":
+if __name__ != "__main__":
     database()

--- a/util/dev.py
+++ b/util/dev.py
@@ -1,0 +1,101 @@
+"""
+Author: @sebastiaan-daniels
+This file contains wrapper functions developers can use to
+request feedback on functions that already exist in production,
+but are not yet fully tested.
+
+Users can give feedback to specific functions by liking or disliking. This will be stored in the database.
+"""
+# Imports
+import functools
+import sqlite3
+import discord
+import discord.ui
+from time import time
+
+class feedback(discord.ui.View):
+    def __init__(self, author: discord.Member,) -> None:
+        super().__init__()
+        self.author = author
+        
+    @discord.ui.button(
+        label="",
+        style=discord.ButtonStyle.green,
+        emoji="👍",
+        disabled=False,
+    )
+    async def button_callback(
+        self,
+        button: discord.ui.Button,
+        interaction: discord.Interaction,
+    ) -> None:
+        self.children[0].disabled = True
+        self.children[1].disabled = True
+        await interaction.response.edit_message(view=self)
+
+    @discord.ui.button(
+        label="False positive",
+        style=discord.ButtonStyle.red,
+        emoji="👎",
+        disabled=False,
+    )
+    async def button_callback(
+        self,
+        button: discord.ui.Button,
+        interaction: discord.Interaction,
+    ) -> None:
+        self.children[0].disabled = True
+        self.children[1].disabled = True
+        await interaction.response.edit_message(view=self)
+
+
+
+def database():
+    """
+    The database should be seperate from the production database.
+    This function creates the db if it doesn't exist yet.
+    An ERD is not necessary for this database.
+    """
+    db = sqlite3.connect("util/dev.sqlite")
+    c = db.cursor()
+    c.execute(
+        """
+        CREATE TABLE IF NOT EXISTS feedback (
+            id INTEGER PRIMARY KEY,
+            time TEXT NOT NULL,
+            author_id INTEGER NOT NULL,
+            function_name TEXT NOT NULL,
+            likes INTEGER NOT NULL,
+            link TEXT NOT NULL
+        );
+        """
+    )
+    db.commit()
+    db.close()
+
+
+def experimental(func):
+    """
+    USAGE:
+
+    @experimental
+    async def function():
+        return tuple[ctx,embed,ephemeral]
+
+    Instead of responding to the user, return your response in a tuple.
+    This wrapper will send the response and add the view.
+    """
+    @functools.wraps(func)
+    async def wrapper(*args, **kwargs):
+        """
+        Wrapper to add a feedback view
+        """
+        r = await func(*args, **kwargs)
+        await r[0].respond(content=r[1], ephemeral=r[2], view=feedback(r[0].author))
+        return r
+    return wrapper
+
+
+if 'a':
+#if __name__ != "__main__":
+    database()

--- a/util/dev.py
+++ b/util/dev.py
@@ -13,7 +13,7 @@ import discord
 import discord.ui
 from time import time
 
-ALLOWED_ROLES = [  # This is not in the env for a reason
+ALLOWED_ROLES = [  # This is ok to be harcoded
     1040358438242365490,  # pax
     892124929590431815, # VH
     267486666292199435, # VC
@@ -40,6 +40,12 @@ class feedback(discord.ui.View):
         button: discord.ui.Button,
         interaction: discord.Interaction,
     ) -> None:
+        if not self.is_allowed():
+            await interaction.response.send_message(
+                "Sorry, only Verified Helpers and above can give feedback!",
+                ephemeral=True,
+            )
+            return
         self.children[0].disabled = True
         self.children[1].disabled = True
         await self.insert(True, interaction)
@@ -56,6 +62,12 @@ class feedback(discord.ui.View):
         button: discord.ui.Button,
         interaction: discord.Interaction,
     ) -> None:
+        if not self.is_allowed():
+            await interaction.response.send_message(
+                "Sorry, only Verified Helpers and above can give feedback!",
+                ephemeral=True,
+            )
+            return
         self.children[0].disabled = True
         self.children[1].disabled = True
         await self.insert(False, interaction)
@@ -73,9 +85,8 @@ class feedback(discord.ui.View):
         db.commit()
         db.close()
 
-    async def is_allowed():
-        ...
-
+    def is_allowed(self):
+        return any([role.id in ALLOWED_ROLES for role in self.author.roles])
 
 
 def database():
@@ -108,7 +119,7 @@ def experimental(func):
 
     @experimental
     async def function():
-        return tuple[ctx | message,embed,ephemeral]
+        return tuple[discord.ApplicationContext | discord.Message, embed | content, ephemeral]
 
     Instead of responding to the user, return your response in a tuple.
     This wrapper will send the response and add the view.


### PR DESCRIPTION
This PR gives Pax developers the option to decorate their command with
`@experimental`
This will add a view to the command result where users that are VH or above can give feedback on a command

closes #219 