### PR TITLE
fix: pycord cannot process string type hints

### DIFF
--- a/cogs/alerts.py
+++ b/cogs/alerts.py
@@ -51,6 +51,12 @@ class Alerts(commands.Cog):
         name="alerts-add",
         description="Adds an alert for a keyword.",
     )
+    @option(
+        "keyword",
+        str,
+        description="The keyword to be alerted on. Regex is supported.",
+        required=True,
+    )
     @limit(1)
     async def add_alert(self, ctx: ApplicationContext, keyword: str) -> None:
         """
@@ -109,7 +115,8 @@ class Alerts(commands.Cog):
         description="Removes an alert for a keyword.",
     )
     @option(
-        name="keyword",
+        "keyword",
+        str,
         description="The keyword to remove.",
         autocomplete=get_keywords,
     )

--- a/cogs/pubchem.py
+++ b/cogs/pubchem.py
@@ -53,7 +53,8 @@ class PubChem(commands.Cog):
         description="Searches the database for a compound.",
     )
     @option(
-        name="name",
+        "name",
+        str,
         description="The name of the compound to be searched.",
         required=True,
     )

--- a/cogs/wikipedia.py
+++ b/cogs/wikipedia.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 
 import wikipedia
+from discord import option
 from discord.ext import commands
 
 from message_formatting.embeds import EmbedBuilder
@@ -36,6 +37,12 @@ class Wikipedia(commands.Cog):
         self.bot = bot
 
     @commands.slash_command(name="wiki", description="Searches Wikipedia for a topic.")
+    @option(
+        "query",
+        str,
+        description="The term or phrase to search.",
+        required=True,
+    )
     @limit(2)
     async def wiki(self, ctx: commands.Context, query: str) -> None:
         """


### PR DESCRIPTION
`from __future__ import annotations` converts _all_ type annotations into strings. Pycord reads these type hints at runtime to determine the schema of slash commands, which makes it incompatible with `__future__.annotations`.

Rather than removing this import, we can just explicitly tell pycord the type for each option (via `@option(name, type)`) so that it doesn't need to be inferred.