### PR TITLE
feat: Add ability to make a command server-only

### DIFF
--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -24,14 +24,13 @@
 
    ```env
    DISCORD_TOKEN = <your discord bot token>
+   GUILD_ID = <main server ID>
    STAFF_CHANNEL = <the channel ID where new applications are sent>
    STAFF_ROLE = <the role ID for staff members>
    ALLOW_SEE_APPS_ROLE = <a role name whose members can see applications>
    MULTIPOST_EMOJI = <optional, specify a custom emoji for multiposts e.g. ":multipost:1046975187930849280">
    ALLOW_MULTIPOST_FOR_ROLE = <a role name whose members are immune to multiposting rules>
-   ALLOW_VIEW_DATABASE_GUILD_ID = <a guild ID where the /view-database command will be enabled>
    ALLOW_VIEW_DATABASE_ROLE_NAME = <a role name whose members can use the /view-database command>
-   ALLOW_DETECT_AI_GUILD = <a guildID where the /detect-ai command will be enabled>
    ALLOW_DETECT_AI_ROLE = <a role name whose members can use the /detect-ai command>
    ALLOW_SURVEY_CHANNEL_ID = <the channel ID for where members can post surveys>
    UNFORMATTED_CODE_DETECTION_CATEGORY_ID = <a category ID where code-formatting tips will be sent automatically>

--- a/cogs/alerts.py
+++ b/cogs/alerts.py
@@ -161,7 +161,8 @@ class Alerts(commands.Cog):
         log(f"Alert removed by $ in {ctx.guild}.", ctx.author)
 
     @commands.slash_command(name="alerts-list", description="Lists all alerts.")
-    @limit(3) # User should still be allowed to remove their alerts if they have too many
+    # User should still be allowed to remove their alerts if they have too many
+    @limit(3)
     @server
     async def list_alerts(self, ctx: ApplicationContext) -> None:
         """

--- a/cogs/alerts.py
+++ b/cogs/alerts.py
@@ -10,7 +10,7 @@ from discord.ext import commands
 
 import database
 from message_formatting.embeds import EmbedBuilder
-from util.limiter import limit
+from util.limiter import limit, server
 from util.logger import log
 
 if TYPE_CHECKING:
@@ -58,6 +58,7 @@ class Alerts(commands.Cog):
         required=True,
     )
     @limit(1)
+    @server
     async def add_alert(self, ctx: ApplicationContext, keyword: str) -> None:
         """
         Checks if the keyword is already in the database, if it is, sends an error message, if it
@@ -121,6 +122,7 @@ class Alerts(commands.Cog):
         autocomplete=get_keywords,
     )
     @limit(1)
+    @server
     async def remove_alert(self, ctx: ApplicationContext, keyword: str) -> None:
         """
         It removes an alert from the database.
@@ -159,8 +161,8 @@ class Alerts(commands.Cog):
         log(f"Alert removed by $ in {ctx.guild}.", ctx.author)
 
     @commands.slash_command(name="alerts-list", description="Lists all alerts.")
-    @limit(3)
-    # User should still be allowed to remove their alerts if they have too many
+    @limit(3) # User should still be allowed to remove their alerts if they have too many
+    @server
     async def list_alerts(self, ctx: ApplicationContext) -> None:
         """
         It gets all alerts from the database and responds with a list of them
@@ -181,6 +183,7 @@ class Alerts(commands.Cog):
 
     @commands.slash_command(name="alerts-clear", description="Clears all alerts.")
     @limit(3)
+    @server
     async def clear_alerts(self, ctx: ApplicationContext) -> None:
         """
         It clears all alerts from the database.
@@ -205,6 +208,7 @@ class Alerts(commands.Cog):
         description="Pauses alerts.",
     )
     @limit(1)
+    @server
     async def pause_alerts(self, ctx: ApplicationContext) -> None:
         """
         It pauses alerts for the user who is currently using the command.
@@ -233,6 +237,7 @@ class Alerts(commands.Cog):
         description="Resumes alerts.",
     )
     @limit(1)
+    @server
     async def resume_alerts(self, ctx: ApplicationContext) -> None:
         """
         It resumes alerts for the user who is currently using the command.

--- a/cogs/misc.py
+++ b/cogs/misc.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 
 LOADING_EMOJI = "\N{Clockwise Downwards and Upwards Open Circle Arrows}"
 COMPLETED_EMOJI = "\N{White Heavy Check Mark}"
-VIEW_DB_GUILD = os.getenv("ALLOW_VIEW_DATABASE_GUILD_ID")
+VIEW_DB_GUILD = os.getenv("GUILD_ID")
 VIEW_DB_ROLE = os.getenv("ALLOW_VIEW_DATABASE_ROLE_NAME")
 VIEW_LOGS_ROLE = os.getenv("ALLOW_VIEW_LOGS_ROLE_NAME")
 STDOUT_LOG_FILE = os.getenv("STDOUT_LOG_FILE", "log.txt")

--- a/util/limiter.py
+++ b/util/limiter.py
@@ -99,7 +99,8 @@ def server(
     func: Callable[LimitedCommandParams, Awaitable[LimitedCommandReturnValue]],
 ) -> Callable[LimitedCommandParams, Awaitable[LimitedCommandReturnValue | None]]:
     """
-    Placeholder text
+    ! This decorator only works on slash commands. !
+    use @server to wrap a slash command to make sure it is only used in the correct guild.
     """
     @functools.wraps(func)
     async def wrapper(

--- a/util/limiter.py
+++ b/util/limiter.py
@@ -92,3 +92,38 @@ def limit(
         return wrapper
 
     return decorator
+
+
+
+def server(
+    func: Callable[LimitedCommandParams, Awaitable[LimitedCommandReturnValue]],
+) -> Callable[LimitedCommandParams, Awaitable[LimitedCommandReturnValue | None]]:
+    """
+    Placeholder text
+    """
+    @functools.wraps(func)
+    async def wrapper(
+        *args: LimitedCommandParams.args,
+        **kwargs: LimitedCommandParams.kwargs,
+    ) -> LimitedCommandReturnValue | None:
+        """
+        Wrapper to determine if the command is used in the correct guild.
+        """
+
+        ctx = None
+        for arg in args:
+            if isinstance(arg, ApplicationContext):
+                ctx = arg
+                break
+
+        if ctx is None:
+            log(
+                f"@limit() decorator was applied to non-slash-command {func!r}! "
+                "Permitting function call without checking permissions!",
+            )
+            return await func(*args, **kwargs)
+
+        return await func(*args, **kwargs)
+
+    return wrapper
+

--- a/util/limiter.py
+++ b/util/limiter.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import functools
 from typing import Awaitable, Callable, ParamSpec, TypeVar
+from os import getenv
 
 from discord import ApplicationContext
 
@@ -12,6 +13,8 @@ from util.logger import log
 LimitedCommandParams = ParamSpec("LimitedCommandParams")
 LimitedCommandReturnValue = TypeVar("LimitedCommandReturnValue")
 
+GUILD_ID = int(getenv("GUILD_ID", "-1"))
+assert GUILD_ID != -1, "GUILD_ID is not set in .env"
 
 def limit(
     limit_level_requirement: int,  # users at this `limitLevel` or higher are banned from using the command

--- a/util/limiter.py
+++ b/util/limiter.py
@@ -122,7 +122,23 @@ def server(
                 "Permitting function call without checking permissions!",
             )
             return await func(*args, **kwargs)
-
+        
+        used_guild_id = ctx.guild_id
+        if used_guild_id is None:
+            log(
+                f"$ tried to use {ctx.command.name}. But is not in a guild.",
+                ctx.author,
+            )
+            await ctx.respond("Sorry, you cannot use this command in dms.", ephemeral=True)
+            return None
+        elif used_guild_id != GUILD_ID: # This should not happen as the bot should only be in one guild.
+            log(
+                f"$ tried to use {ctx.command.name}. But is not in the correct guild.",
+                ctx.author,
+            )
+            await ctx.respond("Sorry, you cannot use this command in this guild.", ephemeral=True)
+            return None
+        
         return await func(*args, **kwargs)
 
     return wrapper

--- a/util/limiter.py
+++ b/util/limiter.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import functools
-from typing import Awaitable, Callable, ParamSpec, TypeVar
 from os import getenv
+from typing import Awaitable, Callable, ParamSpec, TypeVar
 
 from discord import ApplicationContext
 
@@ -15,6 +15,7 @@ LimitedCommandReturnValue = TypeVar("LimitedCommandReturnValue")
 
 GUILD_ID = int(getenv("GUILD_ID", "-1"))
 assert GUILD_ID != -1, "GUILD_ID is not set in .env"
+
 
 def limit(
     limit_level_requirement: int,  # users at this `limitLevel` or higher are banned from using the command
@@ -94,7 +95,6 @@ def limit(
     return decorator
 
 
-
 def server(
     func: Callable[LimitedCommandParams, Awaitable[LimitedCommandReturnValue]],
 ) -> Callable[LimitedCommandParams, Awaitable[LimitedCommandReturnValue | None]]:
@@ -102,6 +102,7 @@ def server(
     ! This decorator only works on slash commands. !
     use @server to wrap a slash command to make sure it is only used in the correct guild.
     """
+
     @functools.wraps(func)
     async def wrapper(
         *args: LimitedCommandParams.args,
@@ -123,24 +124,30 @@ def server(
                 "Permitting function call without checking permissions!",
             )
             return await func(*args, **kwargs)
-        
+
         used_guild_id = ctx.guild_id
         if used_guild_id is None:
             log(
                 f"$ tried to use {ctx.command.name}. But is not in a guild.",
                 ctx.author,
             )
-            await ctx.respond("Sorry, you cannot use this command in dms.", ephemeral=True)
+            await ctx.respond(
+                "Sorry, you cannot use this command in dms.",
+                ephemeral=True,
+            )
             return None
-        elif used_guild_id != GUILD_ID: # This should not happen as the bot should only be in one guild.
+        if used_guild_id != GUILD_ID:
+            # This should not happen as the bot should only be in one guild.
             log(
                 f"$ tried to use {ctx.command.name}. But is not in the correct guild.",
                 ctx.author,
             )
-            await ctx.respond("Sorry, you cannot use this command in this guild.", ephemeral=True)
+            await ctx.respond(
+                "Sorry, you cannot use this command in this guild.",
+                ephemeral=True,
+            )
             return None
-        
+
         return await func(*args, **kwargs)
 
     return wrapper
-


### PR DESCRIPTION
a) This PR adds a decorator to the `limiter.py` file which can be imported in a cog.
Decorating a slash command with this wrapper will make the command usable only in the guild set in the `env`.

b) All alert commands have been decorated with this wrapper
(closes #244 )

@sebastiaan-daniels : Update production ENV on merge